### PR TITLE
fix get dnsconfig error

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -361,7 +361,7 @@ final class Auth
      */
     private function getRemoteApiUri()
     {
-        $uri = self::$DNS_URL . '/easemob/server.json?app_key=' . $this->appKey;
+        $uri = self::$DNS_URL . '/easemob/server.json?app_key=' . urlencode($this->appKey);
         $resp = Http::get($uri);
         if ($resp->ok()) {
             $data = $resp->data();


### PR DESCRIPTION
当自动获取 appkey 服务端地址时, 由于 appkey 没有 encode, 导致获取的集群服务端地址一直是 北京一区地址